### PR TITLE
changes of using isEmpty()

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -885,7 +885,7 @@ public class ChartView extends View {
                 break;
             }
         }
-        if (firstChartSeries != null && chartPoints.size() > 0) {
+        if (firstChartSeries != null && chartPoints.isEmpty()) {
             final int drawXCordinate = getX(maxX) - pointer.getIntrinsicWidth() / 2;
             final double value = firstChartSeries.extractDataFromChartPoint(last);
             final int drawYCordinate = getY(firstChartSeries, value) - pointer.getIntrinsicHeight();


### PR DESCRIPTION
The current implementation of empty collection check in the code relies on size() == 0 which introduces unnecessary complexity to the code and obscures the original intention. So, I used isEmpty() method which checks whether the collection is empty or not. Adopting isEmpty() over size() == 0 aligns with best practices and can make future code maintenance and modifications more straightforward.