### PR TITLE
Pull request for solving Issue #18 : Rename "markers" which hides the field declared at line 93 [ChartView.java:806]

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -803,16 +803,16 @@ public class ChartView extends View {
     }
 
     private List<Double> getXAxisMarkerPositions(final double interval) {
-        final List<Double> markers = new ArrayList<>();
-        markers.add(0d);
+        final List<Double> xAxisMarkers = new ArrayList<>();
+        xAxisMarkers.add(0d);
         for (int i = 1; i * interval < maxX; i++) {
-            markers.add(i * interval);
+            xAxisMarkers.add(i * interval);
         }
 
-        if (markers.size() < 2) {
-            markers.add(maxX);
+        if (xAxisMarkers.size() < 2) {
+            xAxisMarkers.add(maxX);
         }
-        return markers;
+        return xAxisMarkers;
     }
 
     /**


### PR DESCRIPTION
**Root Cause for the technical debt**
There is a class level variable with the name "markers", and the developer has declared a local variable with the same name, i.e. "markers", inside a function [getXAxisMarkerPositions()] in the same class.

**Detected By**
SonarCloud integration with the github repo

**Issue Location**
ChartView.java - line 806
Referred class variable at line 93

**Solution**
Rename the variable "markers" in function getXAxisMarkerPositions()
Solved in: Branch - Avi_Issue18 , Commit - 51c4d45